### PR TITLE
Feedback on Materials

### DIFF
--- a/src/configs/navigation.js
+++ b/src/configs/navigation.js
@@ -145,7 +145,7 @@ export default {
         {
           icon: 'mdi-folder-open',
           key: '',
-          text: 'Gestión de Workspaces',
+          text: 'Categorías y Materiales',
           to: { name: 'manage-workspaces' },
           roles: 'admin'
         },

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,0 +1,4 @@
+export const MATERIAL_TYPES_LABELS = {
+  material: 'Material',
+  recording: 'Grabación'
+}

--- a/src/modules/resources/components/form/tags-auto-complete.vue
+++ b/src/modules/resources/components/form/tags-auto-complete.vue
@@ -1,12 +1,12 @@
 <template>
   <ValidationProvider
+    ref="autocomplete"
     v-slot="{ errors }"
     mode="aggressive"
     :rules="rules"
     name="etiquetas"
   >
     <v-autocomplete
-      ref="autocomplete"
       :value="tags"
       :items="tagsList"
       :loading="loading"
@@ -95,7 +95,7 @@ export default {
       )
     },
     resetErrors() {
-      this.$refs['autocomplete'] && this.$refs['autocomplete'].resetValidation()
+      this.$refs['autocomplete'] && this.$refs['autocomplete'].reset()
     }
   }
 }

--- a/src/modules/resources/components/form/tags-auto-complete.vue
+++ b/src/modules/resources/components/form/tags-auto-complete.vue
@@ -1,32 +1,41 @@
 <template>
-  <v-autocomplete
-    :value="tags"
-    :items="tagsList"
-    :loading="loading"
-    tags-list
-    clearable
-    label="Etiquetas"
-    multiple
-    solo
-    outlined
-    :dense="dense"
-    @change="onChangeTags"
-    @update:search-input="loadTags"
+  <ValidationProvider
+    v-slot="{ errors }"
+    mode="aggressive"
+    :rules="rules"
+    name="etiquetas"
   >
-    <template v-slot:selection="{ attrs, item, select, selected }">
-      <v-chip
-        v-bind="attrs"
-        :input-value="selected"
-        close
-        small
-        @click="select"
-        @click:close="remove(item)"
-      >
-        <strong>{{ item }}</strong
-        >&nbsp;
-      </v-chip>
-    </template>
-  </v-autocomplete>
+    <v-autocomplete
+      ref="autocomplete"
+      :value="tags"
+      :items="tagsList"
+      :loading="loading"
+      :error-messages="errors"
+      tags-list
+      clearable
+      label="Etiquetas"
+      multiple
+      solo
+      outlined
+      :dense="dense"
+      @change="onChangeTags"
+      @update:search-input="loadTags"
+    >
+      <template v-slot:selection="{ attrs, item, select, selected }">
+        <v-chip
+          v-bind="attrs"
+          :input-value="selected"
+          close
+          small
+          @click="select"
+          @click:close="remove(item)"
+        >
+          <strong>{{ item }}</strong>
+          &nbsp;
+        </v-chip>
+      </template>
+    </v-autocomplete>
+  </ValidationProvider>
 </template>
 
 <script>
@@ -49,6 +58,10 @@ export default {
     tags: {
       type: Array,
       default: () => []
+    },
+    rules: {
+      type: String,
+      default: ''
     }
   },
   data() {
@@ -80,6 +93,9 @@ export default {
         'change',
         this.tags.filter((tag) => tag !== item)
       )
+    },
+    resetErrors() {
+      this.$refs['autocomplete'] && this.$refs['autocomplete'].resetValidation()
     }
   }
 }

--- a/src/modules/resources/components/resources/add-material-modal.vue
+++ b/src/modules/resources/components/resources/add-material-modal.vue
@@ -44,7 +44,7 @@
               ref="nameInput"
               v-model="name"
               label="Nombre del Material"
-              rules="required|min:3|max:25|regex:^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ _-]+$"
+              rules="required|min:3|max:50|regex:^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ _-]+$"
             />
             <FieldInput
               v-if="type === 'recording'"
@@ -117,6 +117,7 @@
               </li>
             </ul>
             <TagsAutoComplete
+              ref="tagsInput"
               :dense="false"
               tag-type="material"
               :tags="tags"
@@ -240,6 +241,7 @@ export default {
       this.$refs['nameInput'] && this.$refs['nameInput'].resetErrors()
       this.$refs['vimeoUrlInput'] && this.$refs['vimeoUrlInput'].resetErrors()
       this.$refs['workspaceInput'] && this.$refs['workspaceInput'].reset()
+      this.$refs['tagsInput'] && this.$refs['tagsInput'].resetErrors()
 
       this.name = ''
       this.workspace = this.defaultWorkspace || ''

--- a/src/modules/resources/components/resources/add-material-modal.vue
+++ b/src/modules/resources/components/resources/add-material-modal.vue
@@ -121,6 +121,7 @@
               :dense="false"
               tag-type="material"
               :tags="tags"
+              rules="required"
               @change="onChangeTags"
             />
             <v-card-actions class="d-flex justify-space-between pa-0">

--- a/src/modules/workspaces/workspace-list/components/NameFieldInput.vue
+++ b/src/modules/workspaces/workspace-list/components/NameFieldInput.vue
@@ -10,7 +10,7 @@
       :value="value"
       name="name"
       :error-messages="errors"
-      label="Workspace Name"
+      label="Nombre"
       :filled="true"
       required
       clearable

--- a/src/modules/workspaces/workspace-list/index.vue
+++ b/src/modules/workspaces/workspace-list/index.vue
@@ -35,7 +35,7 @@ export default {
   },
   head: {
     title: {
-      inner: 'Gestión de Workspaces'
+      inner: 'Gestión de Categorías'
     }
   }
 }

--- a/src/modules/workspaces/workspace-material-list/components/workspace-materials-list.vue
+++ b/src/modules/workspaces/workspace-material-list/components/workspace-materials-list.vue
@@ -27,10 +27,7 @@
 
           <v-spacer />
 
-          <resource-button
-            icon-button="mdi-autorenew"
-            @click="resetTableOptions"
-          />
+          <resource-button icon-button="mdi-autorenew" @click="reset()" />
         </v-toolbar>
 
         <!-- ------------ SEARCH ------------ -->
@@ -378,6 +375,10 @@ export default {
           URL.revokeObjectURL(link.href)
         })
         .catch(console.error)
+    },
+    reset() {
+      this.resetTableOptions()
+      this.$refs.table.reload()
     }
   }
 }

--- a/src/modules/workspaces/workspace-material-list/components/workspace-materials-list.vue
+++ b/src/modules/workspaces/workspace-material-list/components/workspace-materials-list.vue
@@ -23,7 +23,7 @@
         <!-- ------------ ACTIONS ------------ -->
         <v-toolbar flat class="indigo lighten-5 my-2" outlined>
           <resource-button-go-back-router />
-          <resource-title-toolbar-datatable title-text="Materials" />
+          <resource-title-toolbar-datatable title-text="Materiales" />
 
           <v-spacer />
 
@@ -61,7 +61,7 @@
             item-text="label"
             item-value="key"
             persistent-hint
-            label="Workspace"
+            label="Categoría"
             dense
             outlined
             class="mr-2"
@@ -86,6 +86,8 @@
       <template v-slot:no-data>
         <resource-banner-no-data-datatable />
       </template>
+
+      <!-- ------------ SLOTS ------------ -->
       <template v-slot:[`item.tags`]="{ item }">
         <div v-if="item.tags">
           <v-chip
@@ -99,8 +101,6 @@
           </v-chip>
         </div>
       </template>
-
-      <!-- ------------ SLOTS ------------ -->
       <template v-slot:[`item.actions-resource`]="{ item }">
         <div class="d-flex justify-space-between align-center">
           <div>
@@ -136,6 +136,9 @@
           />
         </div>
       </template>
+      <template v-slot:[`item.type`]="{ item }">
+        {{ MATERIAL_TYPES_LABELS[item.type] || 'aa' }}
+      </template>
     </ServerDataTable>
   </v-card-text>
 </template>
@@ -150,7 +153,7 @@ import WorkspaceRepository from '@/services/WorkspaceRepository'
 import WorkspaceMaterialRepository from '@/services/WorkspaceMaterialRepository'
 import ServerDataTable from '@/modules/resources/components/resources/server-data-table.vue'
 import axios from 'axios'
-
+import { MATERIAL_TYPES_LABELS } from '@/helpers/constants'
 export default {
   name: 'WorkspaceList',
   components: {
@@ -205,6 +208,7 @@ export default {
   mixins: [componentButtonsCrud],
   data() {
     return {
+      MATERIAL_TYPES_LABELS,
       name: '',
       types: [
         {


### PR DESCRIPTION
## Context

- Imagino que la parte de etiquetas se realizará más adelante, pero esta parte de asignación de un material a un tema (etiqueta) no puedo probarlo completamente. 🎫  
Cuando entras en la ventana de materiales, cambiar el texto que aparece a la derecha del botón volver "Materials" -> "Materiales". :white_check_mark: 
- Si pulso sobre el botón de descargar material no me hace nada. Da un error 401 por consola. Imagino que será algo del acceso a cloudbinary. :white_check_mark: 
- Un material debería tener asociado obligatoriamente una etiqueta. ✅ 
- Se puede ampliar el tamaño del nombre del material a 50? ✅  
- Cuando se listan los materiales cambiar los lieterales de tipo de material. "Material" -> "Material" y "Recording" -> "Grabación" :white_check_mark: 
- Cambiar literales tanto en el menu izquierdo como en las pantallas. "Workspace" -> "Categoria" y "Workspaces" -> "Categorias" :white_check_mark:  (He visto el menu izquierdo y en un input) 
