### PR TITLE
DBT-737 Chore/calendar feedback

### DIFF
--- a/src/modules/lessons/calendar-lessons-list/index.vue
+++ b/src/modules/lessons/calendar-lessons-list/index.vue
@@ -18,7 +18,7 @@
 
               <div>
                 <span class="font-weight-bold subtitle-2">Fecha: </span>
-                {{ lesson.date }}
+                {{ dateFormat(lesson.date) }}
               </div>
 
               <!-- Column for Time -->
@@ -67,7 +67,7 @@
             </template>
           </LessonToolBar>
 
-          <CalendarLessonsList @lesson="onLesson" @load="onLessonLoad" />
+          <CalendarLessonsList @onFocus="onFocus" @lesson="onLesson" @load="onLessonLoad" :focus="date" />
           <div class="d-flex justify-end my-2">
             <ResourceButtonAdd
               class="ml-16"
@@ -84,12 +84,14 @@
 <script>
 import notifications from '@/mixins/notifications'
 import { mapState, mapMutations } from 'vuex'
+import moment from 'moment'
+
 export default {
   name: 'CalendarLesson',
   components: {
     CalendarLessonsList: () =>
       import(
-        /* webpackChunkName: "CalendarLessonsList" */ './components/calendar-lessons-list.vue'
+        /* webpackChunkName: "CalendarLessonsList" */ '../common/calendar-lessons-list.vue'
       ),
     LessonToolBar: () =>
       import(
@@ -112,7 +114,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('lessonsStore', ['lesson']),
+    ...mapState('lessonsStore', ['lesson', 'date']),
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown
     }
@@ -124,7 +126,13 @@ export default {
     this.loadNotifications()
   },
   methods: {
-    ...mapMutations('lessonsStore', ['SET_LESSON']),
+    ...mapMutations('lessonsStore', ['SET_LESSON', 'SET_DATE']),
+    dateFormat(date) {
+      return moment(date).format('DD-MM-YYYY')
+    },
+    onFocus(value) {
+      this.SET_DATE(value)
+    },
     addLesson() {
       this.SET_LESSON(false)
       this.$router.push({ name: 'create-lessons' })

--- a/src/modules/lessons/calendar-lessons-list/index.vue
+++ b/src/modules/lessons/calendar-lessons-list/index.vue
@@ -42,7 +42,7 @@
               <ResourceButtonAdd
                 class="ml-16"
                 text-button="Crear Clase"
-                @click="addLesson"
+                @click="addLesson(date)"
               />
             </template>
             <template v-if="lesson" slot="actions">
@@ -67,7 +67,14 @@
             </template>
           </LessonToolBar>
 
-          <CalendarLessonsList @onFocus="onFocus" @lesson="onLesson" @load="onLessonLoad" :focus="date" />
+          <CalendarLessonsList
+            :focus="date"
+            :type="type"
+            @type="SET_TYPE"
+            @lesson="onLesson"
+            @load="onLessonLoad"
+            @focus="SET_DATE"
+          />
           <div class="d-flex justify-end my-2">
             <ResourceButtonAdd
               class="ml-16"
@@ -114,7 +121,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('lessonsStore', ['lesson', 'date']),
+    ...mapState('lessonsStore', ['lesson', 'date', 'type']),
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown
     }
@@ -126,16 +133,14 @@ export default {
     this.loadNotifications()
   },
   methods: {
-    ...mapMutations('lessonsStore', ['SET_LESSON', 'SET_DATE']),
+    ...mapMutations('lessonsStore', ['SET_LESSON', 'SET_DATE', 'SET_TYPE']),
     dateFormat(date) {
-      return moment(date).format('DD-MM-YYYY')
+      return moment(date).format('DD/MM/YYYY')
     },
-    onFocus(value) {
-      this.SET_DATE(value)
-    },
-    addLesson() {
+
+    addLesson(date = undefined) {
       this.SET_LESSON(false)
-      this.$router.push({ name: 'create-lessons' })
+      this.$router.push({ name: 'create-lessons', query: { date } })
     },
     onLesson(lesson) {
       this.SET_LESSON(lesson || false)
@@ -143,6 +148,7 @@ export default {
         this.$router.push({ name: 'create-lessons' })
       }
     },
+
     onLessonLoad(lesson) {
       // Only on first load
       if (this.lesson) {

--- a/src/modules/lessons/calendar-lessons-list/lessons.store.js
+++ b/src/modules/lessons/calendar-lessons-list/lessons.store.js
@@ -2,10 +2,14 @@ export default {
   name: 'lessonsStore',
   namespaced: true,
   state: {
-    lesson: false
+    lesson: false,
+    date: ''
   },
   mutations: {
     SET_LESSON(state, payload) {
+      state.lesson = payload
+    },
+    SET_DATE(state, payload) {
       state.lesson = payload
     }
   }

--- a/src/modules/lessons/calendar-lessons-list/lessons.store.js
+++ b/src/modules/lessons/calendar-lessons-list/lessons.store.js
@@ -3,14 +3,18 @@ export default {
   namespaced: true,
   state: {
     lesson: false,
-    date: ''
+    date: '',
+    type: 'month'
   },
   mutations: {
     SET_LESSON(state, payload) {
       state.lesson = payload
     },
     SET_DATE(state, payload) {
-      state.lesson = payload
+      state.date = payload
+    },
+    SET_TYPE(state, payload) {
+      state.type = payload
     }
   }
 }

--- a/src/modules/lessons/common/calendar-lessons-list.vue
+++ b/src/modules/lessons/common/calendar-lessons-list.vue
@@ -39,20 +39,22 @@
         <v-sheet :height="$vuetify.breakpoint.mdAndUp ? 600 : undefined">
           <v-calendar
             ref="calendar"
-            v-model="focus"
+            :value="focus"
             color="primary"
             :events="events"
             :event-color="getEventColor"
             :type="computedType"
-            :first-interval="7"
+            :first-interval="8"
             :interval-minutes="60"
-            :interval-count="15"
+            :interval-count="13"
             locale="es-MX"
+            :weekdays="calendarDay"
             @click:event="showEvent"
             @click:more="viewDay"
             @click:date="viewDay"
             @change="updateRange"
           ></v-calendar>
+
         </v-sheet>
       </v-col>
     </v-row>
@@ -69,8 +71,13 @@ export default {
   name: 'CalendarLessonsList',
   components: {},
   mixins: [componentButtonsCrud],
+  props: {
+    focus:{
+      type: String,
+      default: ''
+    }
+  },
   data: () => ({
-    focus: '',
     from: '',
     to: '',
     lessons: [], // Full lesson object
@@ -86,6 +93,9 @@ export default {
       const { title } = this.$refs.calendar
 
       return title.charAt(0).toUpperCase() + title.slice(1)
+    },
+    calendarDay() {
+      return [1, 2, 3, 4, 5, 6, 0]
     },
     computedType() {
       if (this.$vuetify.breakpoint.xs) {
@@ -120,6 +130,8 @@ export default {
     },
     next() {
       this.$refs.calendar.next()
+      console.log('focus', this.focus)
+      this.$emit('onFocus', this.focus)
     },
     async showEvent({ event }) {
       const lesson = this.lessons.find((item) => item.id === event.id)

--- a/src/modules/lessons/create-lesson/index.vue
+++ b/src/modules/lessons/create-lesson/index.vue
@@ -79,7 +79,7 @@
                   id="is_active"
                   :value="isActiveLesson"
                   :label="isActiveLesson ? 'Activa' : 'Inactiva'"
-                  @change="activateLesson"
+                  @click="activateLesson"
                 />
               </v-col>
             </v-row>
@@ -293,6 +293,29 @@ export default {
     async activateLesson(value) {
       const active = value || false // is returning  NULL instead of false
 
+      if (active === true) {
+        const result = await this.$swal.fire({
+        toast: true,
+        width: '400px',
+        icon: 'question',
+        title: 'Eliminar',
+        html: '<b>Esta acción es irreversible</b><br>¿Seguro que deseas eliminar esta clase?',
+        showConfirmButton: true,
+        showCancelButton: true,
+        confirmButtonColor: '#007bff',
+        confirmButtonText: 'Sí, eliminar',
+        cancelButtonText: 'Cancelar'
+      })
+
+      if (!result.isConfirmed) {
+        this.$nextTick(() => {
+          this.isActiveLesson = false
+        })
+
+        return
+      }
+      }
+
       const res = await LessonRepository.active(this.lesson.id, {
         active
       })
@@ -303,6 +326,7 @@ export default {
       this.isActiveLesson = active
       this.lesson.is_active = active
       this.SET_LESSON(this.lesson)
+      this.reset()
     },
     async deleteLesson() {
       if (this.lesson.is_active) {

--- a/src/modules/lessons/create-lesson/index.vue
+++ b/src/modules/lessons/create-lesson/index.vue
@@ -8,7 +8,7 @@
             <FieldInput
               id="name"
               v-model="name"
-              label="Nombre del Lession"
+              label="Nombre de la Clase"
               :filled="true"
               :outlined="false"
               :disabled="!canEdit"
@@ -29,7 +29,7 @@
                   :disabled="!canEdit"
                   :value="start_time"
                   label="Hora de inicio"
-                  rules="required"
+                  rules="required|after:07:00, 7:00"
                   @change="selectedStartTime"
                 />
               </v-col>
@@ -39,7 +39,7 @@
                   :value="end_time"
                   :disabled="!canEdit"
                   label="Hora de finalización"
-                  rules="required|after:@start_time,la hora de inicio"
+                  rules="required|after:@start_time,la hora de inicio|before:21:00, 21:00"
                   @change="selectedEndTime"
                 />
               </v-col>
@@ -51,7 +51,7 @@
                   :value="isOnlineLesson"
                   :disabled="!canEdit"
                   label="Clase Online"
-                  @change="setOnline"
+                  @click="setOnline"
                 />
               </v-col>
               <v-col v-if="isOnlineLesson" cols="12" md="8" class="py-0 pl-0">
@@ -204,7 +204,7 @@ export default {
       this.name = ''
       this.date = ''
       this.comment = ''
-      this.date = ''
+      this.date = this.$route.query.date || ''
       this.start_time = ''
       this.end_time = ''
       this.lessonMeetingUrl = ''
@@ -276,7 +276,7 @@ export default {
         await this.$swal.fire({
           icon: 'success',
           toast: true,
-          title: this.lesson ? 'Lección Actualizada!' : 'Lession Creada!',
+          title: this.lesson ? 'Clase Actualizada!' : 'Clase Creada!',
           showConfirmButton: true,
           confirmButtonText: 'Entendido',
           timer: 7500
@@ -295,25 +295,25 @@ export default {
 
       if (active === true) {
         const result = await this.$swal.fire({
-        toast: true,
-        width: '400px',
-        icon: 'question',
-        title: 'Eliminar',
-        html: '<b>Esta acción es irreversible</b><br>¿Seguro que deseas eliminar esta clase?',
-        showConfirmButton: true,
-        showCancelButton: true,
-        confirmButtonColor: '#007bff',
-        confirmButtonText: 'Sí, eliminar',
-        cancelButtonText: 'Cancelar'
-      })
-
-      if (!result.isConfirmed) {
-        this.$nextTick(() => {
-          this.isActiveLesson = false
+          toast: true,
+          width: '400px',
+          icon: 'question',
+          title: 'Activar Clase',
+          html: 'Si activa esta clase, los alumnos serán notificados y podrán acceder a los materiales.',
+          showConfirmButton: true,
+          showCancelButton: true,
+          confirmButtonColor: '#007bff',
+          confirmButtonText: 'Sí, activala',
+          cancelButtonText: 'Cancelar'
         })
 
-        return
-      }
+        if (!result.isConfirmed) {
+          this.$nextTick(() => {
+            this.isActiveLesson = false
+          })
+
+          return
+        }
       }
 
       const res = await LessonRepository.active(this.lesson.id, {

--- a/src/modules/resources/components/form/date-input.vue
+++ b/src/modules/resources/components/form/date-input.vue
@@ -1,6 +1,7 @@
 <template>
   <v-menu
     ref="datePicker"
+    v-model="isOpen"
     :close-on-content-click="false"
     transition="scale-transition"
     offset-y
@@ -68,7 +69,8 @@ export default {
     }
   },
   data: () => ({
-    date: ''
+    date: '',
+    isOpen: false
   }),
   computed: {
     dateFormatted() {
@@ -100,6 +102,7 @@ export default {
     onCalendarChange(value) {
       this.date = value
       this.emitDate()
+      this.isOpen = false
     },
     emitDate() {
       this.$emit('datePicked', this.dateFormatted)

--- a/src/modules/resources/components/form/switch-input.vue
+++ b/src/modules/resources/components/form/switch-input.vue
@@ -13,6 +13,7 @@
       :value="value"
       :error-messages="errors"
       :label="label"
+      :disabled="disabled"
       readonly
       @click="onClick"
     ></v-switch>
@@ -31,21 +32,21 @@ export default {
       type: String,
       default: ''
     },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
     id: {
       type: String,
       required: true
     }
   },
-  watch: {
-    value: {
-      handler(value) {
-        console.log({ value })
-      },
-      immediate: true
-    }
-  },
+
   methods: {
     onClick() {
+      if (this.disabled) {
+        return
+      }
       this.$emit('click', !this.value)
     }
   }

--- a/src/modules/resources/components/form/switch-input.vue
+++ b/src/modules/resources/components/form/switch-input.vue
@@ -13,7 +13,8 @@
       :value="value"
       :error-messages="errors"
       :label="label"
-      @change="onClick"
+      readonly
+      @click="onClick"
     ></v-switch>
   </ValidationProvider>
 </template>
@@ -35,9 +36,17 @@ export default {
       required: true
     }
   },
+  watch: {
+    value: {
+      handler(value) {
+        console.log({ value })
+      },
+      immediate: true
+    }
+  },
   methods: {
-    onClick(value) {
-      this.$emit('change', value)
+    onClick() {
+      this.$emit('click', !this.value)
     }
   }
 }

--- a/src/plugins/vee-validate.js
+++ b/src/plugins/vee-validate.js
@@ -28,7 +28,7 @@ extend('valid_date', {
 })
 
 extend('before', {
-  validate: (value, { target }) => value < target,
+  validate: (value, { target }) => value <= target,
   message: 'El valor debe ser inferior a {field}',
   params: ['target', 'field']
 })
@@ -40,7 +40,7 @@ extend('url', {
 })
 
 extend('after', {
-  validate: (value, { target }) => value > target,
+  validate: (value, { target }) => value >= target,
   message: 'El valor debe ser posterior a {field}',
   params: ['target', 'field']
 })


### PR DESCRIPTION
## Context

[Slack Thread](https://academy-750.slack.com/archives/C05GN9A2STA/p1692772533157899)

## Test
**CALENDARS**

Date at the top in dd/MM/yyyy format.  :white_check_mark:

Can the calendar go from Monday to Sunday instead of Sunday to Saturday?  :white_check_mark:

On day 31, "2 more" appears, but even putting it in weekly view, I don't see those two more options. I don't know if they are not there or if there is some problem. :white_check_mark:

When I enter the calendar, it marks the current day, but in the class selected at the top, it leaves me selected the last one I consulted. As the data is right now, I should mark the first class on 08/23.

**CREATE CLASS**

Change the "Lession" literals to "Lesson" or "Class". (In the created class popup too)  :white_check_mark:

When I select a day, can the calendar be closed automatically?   :white_check_mark:
If I click on "Online Class" and then edit I get an error asking me to enter the url of the online class (this is correct). If right after I remove the online class and I give active class I get an error telling me that the value of the online class has to be true or false.   :white_check_mark:

> We can not reproduce, but we fixed the logic and added a warning before making it active

**MOBILE VERSION CALENDAR**

When looking for days, if I look for a day where I have class, I enter the class and right after I go back it takes me again to the current day.   (Selected date on the reducer) ✅ 

Is it possible to mark in some way or through a text, what will be the next class of the student? Although it shows me the current day in which I have nothing but tell me, on day X do you have your next class? (edited)

> Will be handle in the STUDENTS calendar
> Added a mini calendar if you open the month

## Platform

<!-- In which platforms you have test it -->

## Proof of Concept

<!-- Any screenshot or recording that shows how is working without need of running the code -->
