### PR TITLE
DBT-918 added assistance to admin

### DIFF
--- a/src/modules/lessons/lesson-students/components/students-table-columns.js
+++ b/src/modules/lessons/lesson-students/components/students-table-columns.js
@@ -23,8 +23,16 @@ export default [
       value: 'group_name',
       show: true
     },
-    {
+  {
       position: 4,
+      sortable: false,
+      text: 'Asistencia',
+      align: 'center',
+      value: 'will_join',
+      show: true
+    },
+    {
+      position: 5,
       sortable: false,
       text: 'Acciones',
       align: 'center',

--- a/src/services/LessonRepository.js
+++ b/src/services/LessonRepository.js
@@ -180,16 +180,18 @@ export default {
    * @param {number} offset
    * @param {number} limit
    * @param {string} lessonId
+   * @param {string} willJoin
    */
   async lessonStudentList(
     lessonId,
-    { orderBy, order, limit, offset, content } = {}
+    { orderBy, willJoin, order, limit, offset, content } = {}
   ) {
     const params = {
       orderBy,
       order,
       limit,
       offset,
+      willJoin,
       content: content || undefined
     }
 
@@ -209,7 +211,8 @@ export default {
     return {
       results: response.data.results,
       groups: response.data.groups,
-      total: response.data.total
+      total: response.data.total,
+      will_join_count: response.data.will_join_count
     }
   },
   /**


### PR DESCRIPTION
## Context

<!-- Why you do this change? What do yoy try to achieve? -->
Here we are adding lesson assistants to the admin side

<!-- Link to the task, or another PRs or important links referent to this task -->
[Add the Assistant Total Join in the admin page too](https://www.notion.so/tianlu/Add-the-Assistant-Total-Join-in-the-admin-page-too-3e4c61a6fe624641ab40e2fc6068591f?pvs=4)

## Test

<!-- How to set up the test -->

- Go to lesson as an admin 
- you can see who will assist and can filter

<!-- How to test step by step -->

## Platform

<!-- In which platforms you have test it -->

## Proof of Concept
<img width="970" alt="image" src="https://github.com/Academia-750/academia750-frontend-vue/assets/79788219/7cbf2805-e706-4d17-9409-339d6b8cc4b7">

<!-- Any screenshot or recording that shows how is working without need of running the code -->
