### PR TITLE
DBT-890 Fixed issue with tags auto complete

### DIFF
--- a/src/modules/resources/components/form/base-multiple-autocomplete.vue
+++ b/src/modules/resources/components/form/base-multiple-autocomplete.vue
@@ -1,0 +1,124 @@
+<template>
+  <ValidationProvider
+    ref="autocomplete"
+    v-slot="{ errors }"
+    mode="aggressive"
+    :rules="rules"
+    :name="name"
+  >
+    <v-autocomplete
+      :search-input="search"
+      :value="values"
+      :items="items"
+      :loading="loading"
+      :error-messages="errors"
+      clearable
+      :label="label || name"
+      multiple
+      solo
+      outlined
+      :dense="dense"
+      :item-text="itemText"
+      :item-value="itemName"
+      @change="change"
+      @update:search-input="load"
+      @focus="cleanSearch"
+    >
+      <template v-slot:selection="{ attrs, item, select, selected }">
+        <v-chip
+          v-bind="attrs"
+          :input-value="selected"
+          close
+          small
+          @click="select"
+          @click:close="remove(item)"
+        >
+          <strong>{{ item }}</strong>
+          &nbsp;
+        </v-chip>
+      </template>
+    </v-autocomplete>
+  </ValidationProvider>
+</template>
+
+<script>
+export default {
+  name: 'BaseMultipleAutocomplete',
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      default: ''
+    },
+    limit: {
+      type: Number,
+      default: 5
+    },
+    dense: {
+      type: Boolean,
+      default: false
+    },
+    values: {
+      type: Array,
+      default: () => []
+    },
+    rules: {
+      type: String,
+      default: ''
+    },
+    loadData: {
+      type: Function,
+      required: true
+    },
+    itemText: {
+      type: String,
+      default: ''
+    },
+    itemName: {
+      type: String,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      search: '',
+      loading: false,
+      items: []
+    }
+  },
+  mounted() {
+    this.load()
+  },
+  methods: {
+    async load(search) {
+      this.search = search
+      this.loading = true
+
+      this.items = await this.loadData(search)
+
+      this.items = [...this.items, ...this.values]
+
+      this.loading = false
+    },
+    change(values) {
+      this.$emit('change', values)
+      this.search = ''
+    },
+    cleanSearch() {
+      this.load('')
+    },
+    remove(item) {
+      this.$emit(
+        'change',
+        this.values.filter((value) => value !== item)
+      )
+    },
+    resetErrors() {
+      this.$refs['autocomplete'] && this.$refs['autocomplete'].reset()
+    }
+  }
+}
+</script>

--- a/src/modules/resources/components/form/lessons-auto-complete.vue
+++ b/src/modules/resources/components/form/lessons-auto-complete.vue
@@ -1,57 +1,32 @@
 <template>
-  <ValidationProvider
+  <BaseAutocomplete
     ref="autocomplete"
-    v-slot="{ errors }"
-    mode="aggressive"
-    :rules="rules"
     name="lessons"
-  >
-    <v-autocomplete
-      :value="lessons"
-      :items="lessonsList"
-      :loading="loading"
-      :error-messages="errors"
-      lessons-list
-      clearable
-      label="Nombre de la clase"
-      multiple
-      solo
-      outlined
-      :dense="dense"
-      item-text="name"
-      item-value="id"
-      @change="onChangelessons"
-      @update:search-input="loadLessons"
-    >
-      <template v-slot:selection="{ attrs, item, select, selected }">
-        <v-chip
-          v-bind="attrs"
-          :input-value="selected"
-          close
-          small
-          @click="select"
-          @click:close="remove(item.id)"
-        >
-          <strong>{{ item.name }}</strong>
-          &nbsp;
-        </v-chip>
-      </template>
-    </v-autocomplete>
-  </ValidationProvider>
+    label="Nombre de la clase"
+    :limit="limit"
+    :values="lessons"
+    :rules="rules"
+    :load-data="loadLessons"
+    item-text="name"
+    item-value="id"
+    @change="onChange"
+  />
 </template>
 
 <script>
+/**
+ * We edited this field but is not in use, maybe next time we use is a little issue on it.
+ */
 import LessonRepository from '@/services/LessonRepository'
+import BaseAutocomplete from './base-multiple-autocomplete.vue'
+
 export default {
   name: 'LessonsAutoComplete',
+  components: { BaseAutocomplete },
   props: {
     limit: {
       type: Number,
       default: 5
-    },
-    dense: {
-      type: Boolean,
-      default: false
     },
     lessons: {
       type: Array,
@@ -62,42 +37,25 @@ export default {
       default: ''
     }
   },
-  data() {
-    return {
-      lessonsList: [],
-      loading: false
-    }
-  },
-  mounted() {
-    this.loadLessons()
-  },
   methods: {
     async loadLessons(value) {
-      this.loading = true
       const lessons = await LessonRepository.searchLessons({
         content: value,
         limit: this.limit
       })
 
-      this.lessonsList = lessons.map((item) => {
+      return lessons.map((item) => {
         return {
           name: item.name,
           id: item.id
         }
       })
-      this.loading = false
     },
-    onChangelessons(value) {
+    onChange(value) {
       this.$emit('change', value)
     },
-    remove(id) {
-      this.$emit(
-        'change',
-        this.lessons.filter((lessonId) => lessonId !== id)
-      )
-    },
     resetErrors() {
-      this.$refs['autocomplete'] && this.$refs['autocomplete'].reset()
+      this.$refs['autocomplete'] && this.$refs['autocomplete'].resetErrors()
     }
   }
 }

--- a/src/modules/resources/components/form/tags-auto-complete.vue
+++ b/src/modules/resources/components/form/tags-auto-complete.vue
@@ -1,55 +1,27 @@
 <template>
-  <ValidationProvider
+  <BaseAutocomplete
     ref="autocomplete"
-    v-slot="{ errors }"
-    mode="aggressive"
-    :rules="rules"
     name="temas"
-  >
-    <v-autocomplete
-      :value="tags"
-      :items="tagsList"
-      :loading="loading"
-      :error-messages="errors"
-      tags-list
-      clearable
-      label="Temas"
-      multiple
-      solo
-      outlined
-      :dense="dense"
-      @change="onChangeTags"
-      @update:search-input="loadTags"
-    >
-      <template v-slot:selection="{ attrs, item, select, selected }">
-        <v-chip
-          v-bind="attrs"
-          :input-value="selected"
-          close
-          small
-          @click="select"
-          @click:close="remove(item)"
-        >
-          <strong>{{ item }}</strong>
-          &nbsp;
-        </v-chip>
-      </template>
-    </v-autocomplete>
-  </ValidationProvider>
+    label="Temas"
+    :limit="limit"
+    :values="tags"
+    :rules="rules"
+    :load-data="loadTags"
+    @change="onChange"
+  />
 </template>
 
 <script>
 import WorkspaceMaterialRepository from '@/services/WorkspaceMaterialRepository'
+import BaseAutocomplete from './base-multiple-autocomplete.vue'
+
 export default {
   name: 'TagsAutoComplete',
+  components: { BaseAutocomplete },
   props: {
     limit: {
       type: Number,
       default: 5
-    },
-    dense: {
-      type: Boolean,
-      default: false
     },
     tagType: {
       type: String,
@@ -64,39 +36,22 @@ export default {
       default: ''
     }
   },
-  data() {
-    return {
-      tagsList: [],
-      loading: false
-    }
-  },
-  mounted() {
-    this.loadTags()
-  },
+
   methods: {
     async loadTags(value) {
-      this.loading = true
-      const tags = await WorkspaceMaterialRepository.searchTags({
+      const items = await WorkspaceMaterialRepository.searchTags({
         content: value,
         limit: this.limit,
         type: this.tagType
       })
 
-      this.tagsList = tags.map((item) => item.name)
-      this.loading = false
+      return items.map((item) => item.name)
     },
-    onChangeTags(value) {
-      this.$emit('change', value)
-    },
-    remove(item) {
-      console.log({ item })
-      this.$emit(
-        'change',
-        this.tags.filter((tag) => tag !== item)
-      )
+    onChange(values) {
+      this.$emit('change', values)
     },
     resetErrors() {
-      this.$refs['autocomplete'] && this.$refs['autocomplete'].reset()
+      this.$refs['autocomplete'] && this.$refs['autocomplete'].resetErrors()
     }
   }
 }


### PR DESCRIPTION
## Context

The multi select tag component is not working right, when we type text is not fully clear and the selected items disappear from the input (despite are selected)

The issue is due to behaviour of veutify auto complete, which require some special business logic to make it work correctly.

We also create `base-multi-autocomplete` to abstract this business logics from the rest of the components.

## Test

Go. to materials page -> any  tag form (to create or search)

Now you can type new tags, selected tags disappear.

If you select a tag, the search will show all the options (is clear)
If you type and don't select a tab, on focus again the input is clear.



