### PR TITLE
Feat/materials different route

### DIFF
--- a/src/helpers/loadUserAuth.js
+++ b/src/helpers/loadUserAuth.js
@@ -3,14 +3,21 @@ import store from '@/store'
 import { $get_token_auth } from '@/helpers/auth'
 import ProfileServiceAfterLogin from '@/services/ProfileServiceAfterLogin'
 import ProfileAuthService from '@/services/ProfileAuthService'
-import { enableLoadingProgressCircular, disabledLoadingProgressCircular } from '@/helpers/manageLoading'
+import {
+  enableLoadingProgressCircular,
+  disabledLoadingProgressCircular
+} from '@/helpers/manageLoading'
 
 export const loadUserAuth = async () => {
   if (Cookies.get('authorization')) {
     try {
       enableLoadingProgressCircular()
-      ProfileServiceAfterLogin.defaults.headers.common['Authorization'] = `Bearer ${$get_token_auth()}`
-      ProfileAuthService.defaults.headers.common['Authorization'] = `Bearer ${$get_token_auth()}`
+      ProfileServiceAfterLogin.defaults.headers.common[
+        'Authorization'
+      ] = `Bearer ${$get_token_auth()}`
+      ProfileAuthService.defaults.headers.common[
+        'Authorization'
+      ] = `Bearer ${$get_token_auth()}`
       await store.dispatch('profileService/getDataMyProfileAction', {
         actionAfterLogin: false,
         configResponse: {

--- a/src/modules/lessons/_common/students-materials-base/students-materials-base.vue
+++ b/src/modules/lessons/_common/students-materials-base/students-materials-base.vue
@@ -8,7 +8,7 @@
   >
     <template v-slot:top>
       <!-- ------------ ACTIONS ------------ -->
-      <Toolbar :title="title" icon="mdi-tag" :back="!!lesson">
+      <Toolbar :title="title" :icon="icon" :back="!!lesson">
         <template #actions>
           <resource-button
             icon-button="mdi-autorenew"
@@ -101,7 +101,8 @@ export default {
     loading: {
       type: Boolean,
       default: false
-    }
+    },
+    icon: { type: String, required: true }
   },
   data() {
     return {}
@@ -124,10 +125,6 @@ export default {
     }
   },
 
-  mounted() {
-    this.loadStudentsMaterials()
-    this.$refs.table.reload()
-  },
   methods: {
     onChangeTags(value) {
       this.$store.commit(`${this.storeName}/SET_TAGS`, value)
@@ -138,7 +135,6 @@ export default {
     onChangeWorkspaces(value) {
       this.$store.commit(`${this.storeName}/SET_WORKSPACES`, value)
       this.$store.commit(`${this.storeName}/SET_TABLE_OPTIONS`, { offset: 0 })
-
       this.$refs.table.reload()
     },
 
@@ -166,6 +162,7 @@ export default {
     },
     resetTableOptions() {
       this.$store.dispatch(`${this.storeName}/resetTableOptions`)
+
       this.$refs.table.reload()
     }
   }

--- a/src/modules/lessons/_common/students-materials-base/students-materials.store.js
+++ b/src/modules/lessons/_common/students-materials-base/students-materials.store.js
@@ -1,7 +1,7 @@
 import DataTableStore from '@/modules/resources/store/data-table.store'
 
-export default {
-  name: 'studentsMaterialsStore',
+export const makeMaterialStore = (name) => ({
+  name,
   namespaced: true,
   state: {
     ...DataTableStore.state,
@@ -34,4 +34,4 @@ export default {
       commit('SET_WORKSPACES', [])
     }
   }
-}
+})

--- a/src/modules/lessons/index.js
+++ b/src/modules/lessons/index.js
@@ -7,6 +7,7 @@ import studentLessonStore from './student-lessons/student-lessons.store'
 import studentsMaterialsStore from './student-materials/students-materials.store'
 import studentsRecordingsStore from './student-recordings/students-recordings.store'
 import router from './lessons.router'
+import { makeMaterialStore } from './_common/students-materials-base/students-materials.store'
 
 export default {
   stores: [
@@ -16,8 +17,10 @@ export default {
     materialsForLessonStore,
     studentLessonStore,
     lessonAttendeesStore,
-    studentsMaterialsStore,
-    studentsRecordingsStore
+    makeMaterialStore('studentsMaterialsStore'),
+    makeMaterialStore('studentsRecordingsStore'),
+    makeMaterialStore('studentsLessonMaterialsStore'),
+    makeMaterialStore('studentsLessonRecordingsStore')
   ],
   router
 }

--- a/src/modules/lessons/lessons.router.js
+++ b/src/modules/lessons/lessons.router.js
@@ -6,8 +6,10 @@ import AddStudentToLessonsModule from './lesson-students'
 import AddMaterialsToLessonsModule from './lesson-material-list'
 import ListOfMaterialsForLessonsModule from './materials-for-lesson-list'
 import StudentLessons from './student-lessons'
-import ManageStudentsMaterialsModule from './student-materials'
-import ManageStudentsRecordingsModule from './student-recordings'
+import StudentMaterialsPage from './student-materials/student-materials-page'
+import StudentLessonMaterialsPage from './student-materials/student-lesson-material-page'
+import StudentRecordingPage from './student-recordings/student-recordings-page'
+import StudentLessonRecordingPage from './student-recordings/student-lesson-recording-page'
 import LessonAttendeesModule from './lesson-attendees'
 import StudentLessonOnlineModule from './student-join-online-clase'
 
@@ -35,17 +37,17 @@ const studentRoute = [
             }
           },
           {
-            path: 'materials',
-            name: 'manage-students-materials',
-            component: ManageStudentsMaterialsModule,
+            path: ':id/materials',
+            name: 'student-lesson-materials',
+            component: StudentLessonMaterialsPage,
             meta: {
               middleware: [authMiddleware]
             }
           },
           {
-            path: 'recordings',
-            name: 'manage-students-recordings',
-            component: ManageStudentsRecordingsModule,
+            path: ':id/recordings',
+            name: 'student-lesson-recordings',
+            component: StudentLessonRecordingPage,
             meta: {
               middleware: [authMiddleware]
             }
@@ -59,6 +61,22 @@ const studentRoute = [
             }
           }
         ]
+      },
+      {
+        path: 'student-materials',
+        name: 'manage-students-materials',
+        component: StudentMaterialsPage,
+        meta: {
+          middleware: [authMiddleware]
+        }
+      },
+      {
+        path: 'student-recordings',
+        name: 'manage-students-recordings',
+        component: StudentRecordingPage,
+        meta: {
+          middleware: [authMiddleware]
+        }
       }
     ]
   }

--- a/src/modules/lessons/student-materials/student-lesson-material-page.vue
+++ b/src/modules/lessons/student-materials/student-lesson-material-page.vue
@@ -1,0 +1,64 @@
+<template>
+  <StudentsMaterialsList
+    v-if="lesson"
+    store-name="studentsLessonMaterialsStore"
+  />
+</template>
+
+<script>
+import notifications from '@/mixins/notifications'
+import { PermissionEnum } from '@/utils/enums'
+import LessonRepository from '@/services/LessonRepository'
+import { mapState, mapMutations } from 'vuex'
+
+export default {
+  name: 'StudentsMaterials',
+  components: {
+    StudentsMaterialsList: () =>
+      import(
+        /* webpackChunkName: "StudentsMaterialsList" */ './students-materials-list.vue'
+      )
+  },
+  mixins: [notifications],
+  computed: {
+    ...mapState('studentsLessonMaterialsStore', ['lesson']),
+    lessonId() {
+      return this.$route.params.id
+    }
+  },
+  mounted() {
+    this.loadNotifications()
+
+    this.loadLesson()
+  },
+
+  beforeCreate() {
+    this.$hasPermissionMiddleware(PermissionEnum.SEE_LESSONS)
+    this.$hasPermissionMiddleware(PermissionEnum.SEE_LESSON_MATERIALS)
+  },
+
+  methods: {
+    ...mapMutations('studentsLessonMaterialsStore', ['SET_LESSON']),
+
+    async loadLesson() {
+      // Already loaded on the reducer
+      if (this.lesson && this.lesson.id === this.lessonId) {
+        return
+      }
+
+      const lesson = await LessonRepository.getStudentLesson(this.lessonId)
+
+      if (!lesson) {
+        return
+      }
+
+      this.SET_LESSON(lesson)
+    }
+  },
+  head: {
+    title: {
+      inner: 'Materiales de clase'
+    }
+  }
+}
+</script>

--- a/src/modules/lessons/student-materials/student-materials-page.vue
+++ b/src/modules/lessons/student-materials/student-materials-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <StudentsMaterialsList />
+  <StudentsMaterialsList store-name="studentsMaterialsStore" />
 </template>
 
 <script>
@@ -15,11 +15,6 @@ export default {
       )
   },
   mixins: [notifications],
-  data() {
-    return {
-      reloadDatatableUsers: false
-    }
-  },
   mounted() {
     this.loadNotifications()
   },

--- a/src/modules/lessons/student-materials/students-materials-list.vue
+++ b/src/modules/lessons/student-materials/students-materials-list.vue
@@ -3,8 +3,9 @@
     <StudentsMaterialsBase
       ref="materialsList"
       :title="`Materiales de la clase ${lesson ? lesson.name : ''}`"
-      store-name="studentsMaterialsStore"
+      :store-name="storeName"
       type="material"
+      icon="mdi-file-pdf"
     >
       <template v-slot:actions="item">
         <div
@@ -49,7 +50,6 @@
 <script>
 import LessonRepository from '@/services/LessonRepository'
 import downloadFile from '@/utils/DownloadMaterial'
-import { mapState } from 'vuex'
 
 export default {
   name: 'StudentsMaterialsList',
@@ -59,14 +59,23 @@ export default {
         /* webpackChunkName: "StudentsMaterialsBase" */ '@/modules/lessons/_common/students-materials-base/students-materials-base.vue'
       )
   },
+  props: {
+    storeName: {
+      type: String,
+      required: true
+    }
+  },
   data() {
     return {
       loading: false
     }
   },
   computed: {
-    ...mapState('studentsMaterialsStore', ['lesson'])
+    lesson() {
+      return this.$store.state[this.storeName].lesson
+    }
   },
+
   methods: {
     async getUrl(material) {
       this.loading = true

--- a/src/modules/lessons/student-recordings/student-lesson-recording-page.vue
+++ b/src/modules/lessons/student-recordings/student-lesson-recording-page.vue
@@ -1,0 +1,67 @@
+<template>
+  <StudentsRecordingsList
+    v-if="lesson"
+    store-name="studentsLessonRecordingsStore"
+  />
+</template>
+
+<script>
+import notifications from '@/mixins/notifications'
+import { PermissionEnum } from '@/utils/enums'
+import { mapState, mapMutations } from 'vuex'
+import LessonRepository from '@/services/LessonRepository'
+
+export default {
+  name: 'StudentsRecordings',
+  components: {
+    StudentsRecordingsList: () =>
+      import(
+        /* webpackChunkName: "StudentsRecordingsList" */ './students-recordings-list.vue'
+      )
+  },
+  mixins: [notifications],
+  data() {
+    return {
+      reloadDatatableUsers: false
+    }
+  },
+  computed: {
+    ...mapState('studentsLessonRecordingsStore', ['lesson']),
+    lessonId() {
+      return this.$route.params.id
+    }
+  },
+  mounted() {
+    this.loadNotifications()
+
+    this.loadLesson()
+  },
+  beforeCreate() {
+    this.$hasPermissionMiddleware(PermissionEnum.SEE_LESSONS)
+    this.$hasPermissionMiddleware(PermissionEnum.SEE_LESSON_MATERIALS)
+  },
+  methods: {
+    ...mapMutations('studentsLessonRecordingsStore', ['SET_LESSON']),
+
+    async loadLesson() {
+      // Already loaded on the reducer
+      if (this.lesson && this.lesson.id === this.lessonId) {
+        return
+      }
+
+      const lesson = await LessonRepository.getStudentLesson(this.lessonId)
+
+      if (!lesson) {
+        return
+      }
+
+      this.SET_LESSON(lesson)
+    }
+  },
+  head: {
+    title: {
+      inner: 'Grabaciones de clase'
+    }
+  }
+}
+</script>

--- a/src/modules/lessons/student-recordings/student-recordings-page.vue
+++ b/src/modules/lessons/student-recordings/student-recordings-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <StudentsRecordingsList />
+  <StudentsRecordingsList store-name="studentsRecordingsStore" />
 </template>
 
 <script>

--- a/src/modules/lessons/student-recordings/students-recordings-list.vue
+++ b/src/modules/lessons/student-recordings/students-recordings-list.vue
@@ -3,8 +3,9 @@
     <StudentsMaterialsBase
       ref="recordingsList"
       :title="`Grabaciones de clase ${lesson ? lesson.name : ''}`"
-      store-name="studentsRecordingsStore"
+      :store-name="storeName"
       type="recording"
+      icon="mdi-camera"
       :loading="loading"
     >
       <template v-slot:actions="item">
@@ -41,7 +42,6 @@
 </template>
 <script>
 import LessonRepository from '@/services/LessonRepository'
-import { mapState } from 'vuex'
 
 export default {
   name: 'StudentsRecordingsList',
@@ -55,15 +55,23 @@ export default {
         /* webpackChunkName: "VimeoVideoPlayer" */ '@/modules/resources/components/resources/vimeo-video-player.vue'
       )
   },
+  props: {
+    storeName: {
+      type: String,
+      required: true
+    }
+  },
   data() {
     return {
       loading: false
     }
   },
   computed: {
-    ...mapState('studentsRecordingsStore', ['lesson'])
+    lesson() {
+      return this.$store.state[this.storeName].lesson
+    }
   },
-  mounted() {},
+
   methods: {
     async getUrl(material) {
       this.loading = true

--- a/src/modules/lessons/student-recordings/students-recordings.store.js
+++ b/src/modules/lessons/student-recordings/students-recordings.store.js
@@ -32,7 +32,6 @@ export default {
       DataTableStore.actions.resetTableOptions({ commit })
       commit('SET_TAGS', [])
       commit('SET_WORKSPACES', [])
-      commit('SET_LESSON', false)
     }
   }
 }

--- a/src/modules/resources/components/resources/lesson-info-modal.vue
+++ b/src/modules/resources/components/resources/lesson-info-modal.vue
@@ -124,24 +124,28 @@ export default {
     ...mapMutations('studentsRecordingsStore', ['SET_LESSONS']),
     ...mapActions('studentLessonsStore', ['updateJoinLesson']),
     setLessonMaterial(lesson) {
-      this.$store.commit('studentsMaterialsStore/SET_LESSON', lesson)
-      this.$store.commit('studentsMaterialsStore/SET_TABLE_OPTIONS', {
+      this.$store.dispatch('studentsLessonMaterialsStore/resetTableOptions')
+
+      this.$store.commit('studentsLessonMaterialsStore/SET_LESSON', lesson)
+      this.$store.commit('studentsLessonMaterialsStore/SET_TABLE_OPTIONS', {
         offset: 0
       })
 
       this.$router.push({
-        name: 'manage-students-materials',
+        name: 'student-lesson-materials',
         params: { id: lesson.id }
       })
     },
     setLessonRecordings(lesson) {
-      this.$store.commit('studentsRecordingsStore/SET_LESSON', lesson)
-      this.$store.commit('studentsRecordingsStore/SET_TABLE_OPTIONS', {
+      this.$store.dispatch('studentsLessonRecordingsStore/resetTableOptions')
+
+      this.$store.commit('studentsLessonRecordingsStore/SET_LESSON', lesson)
+      this.$store.commit('studentsLessonRecordingsStore/SET_TABLE_OPTIONS', {
         offset: 0
       })
 
       this.$router.push({
-        name: 'manage-students-recordings',
+        name: 'student-lesson-recordings',
         params: { id: lesson.id }
       })
     },

--- a/src/services/LessonRepository.js
+++ b/src/services/LessonRepository.js
@@ -194,7 +194,7 @@ export default {
       willJoin,
       content: content || undefined
     }
-    
+
     deleteUndefined(params)
     const response = await ResourceService.get(`lesson/${lessonId}/students`, {
       params
@@ -421,6 +421,32 @@ export default {
 
     return true
   },
+
+  /**
+   * @param {string} id
+   */
+  async getStudentLesson(id) {
+    const response = await ResourceService.get(`student-lessons/${id}/info`)
+
+    if (response.status === 404) {
+      activateError({
+        status: 404,
+        message: 'Lección no encontrada'
+      })
+
+      return false
+    }
+    if (response.status !== 200) {
+      ResourceService.warning({
+        response
+      })
+
+      return false
+    }
+
+    return response.data.result
+  },
+
   /**
    * @param {string} id
    * @param {string} orderBy


### PR DESCRIPTION
## Context

- When the  student click in the materials / recordings he can see all of them.
- When the student click in the materials / recordings of a class can see only these ones.

These two features were using the same component and reducer, so the options selected in one were impacting in the other one.

Despite we want to reuse the components, the store shall be independent among them.

We have created a single store which is built dynamically with the same name.

Note that we have now `student-recordings` and `lessons/ID/recordings` path (same for materials

## Test

Check that all works fine
- [] You can see all the materials, and filters by all 3 fields. Going to another page and coming back keep the filters. Reset works correctly.
- [] You can see all the Recordings, and filters by all 3 fields. Going to another page and coming back keep the filters. Reset works correctly. 
- You can see all the materials of a class, and filters by all 3 fields. Going to another page and coming back keep the filters. Reset works correctly.
- [] You can see all the Recordings of a class, and filters by all 3 fields. Going to another page and coming back keep the filters. Reset works correctly. 

Check the mixing between them
- Material Lesson Filters are not applied to all materials and vice versa.
- If you open lesson materials (add some filters) go to materials (add other filters) go to another page. Now click back twice, each page keeps its own filters.

Checking reload:
- If you go to a lesson materials, and reload, the lesson is reloaded from the API
<!-- How to test step by step -->

## Platform

Andriod

## Proof of Concept

<img width="1015" alt="image" src="https://github.com/Academia-750/academia750-frontend-vue/assets/37141039/5db81ceb-25b1-42ce-abc2-26f81551563f">

<img width="956" alt="image" src="https://github.com/Academia-750/academia750-frontend-vue/assets/37141039/19267eb9-ea77-47fe-a5b5-cb13109e19a1">

