### PR TITLE
DBT-959 Testing moving the auto complete and making it full screen

### DIFF
--- a/src/modules/lessons/student-join-online-clase/students-online-lesson.vue
+++ b/src/modules/lessons/student-join-online-clase/students-online-lesson.vue
@@ -141,6 +141,7 @@ export default {
         timeDifference <= 30 * MINUTE &&
         endTimeDifference + 15 * MINUTE >= 0
       ) {
+        this.classNotStarted = false
         this.classOngoing = true
         this.classEnded = false
 

--- a/src/modules/resources/components/resources/add-material-modal.vue
+++ b/src/modules/resources/components/resources/add-material-modal.vue
@@ -1,6 +1,11 @@
 <template>
   <v-row justify="center">
-    <v-dialog v-model="isOpen" max-width="450px" @close="onClose">
+    <v-dialog
+      v-model="isOpen"
+      max-width="450px"
+      :fullscreen="isMobile"
+      @close="onClose"
+    >
       <validation-observer ref="formCreateWorkspaceMaterial">
         <v-card class="d-flex flex-column">
           <v-container class="pa-3">
@@ -54,6 +59,14 @@
               v-model="url"
               label="Video URL (Vimeo)"
               rules="required"
+            />
+            <TagsAutoComplete
+              ref="tagsInput"
+              :dense="false"
+              tag-type="material"
+              :tags="tags"
+              rules="required"
+              @change="onChangeTags"
             />
             <v-progress-linear
               v-if="uploading"
@@ -122,14 +135,7 @@
               </li>
               <h5 class="font-weight-regular">El tamaño máximo es 10 MB</h5>
             </ul>
-            <TagsAutoComplete
-              ref="tagsInput"
-              :dense="false"
-              tag-type="material"
-              :tags="tags"
-              rules="required"
-              @change="onChangeTags"
-            />
+
             <v-card-actions class="d-flex justify-space-between pa-0">
               <v-btn
                 color="blue-darken-1"
@@ -230,6 +236,9 @@ export default {
     },
     typeLabel() {
       return this.type === 'material' ? 'Material' : 'Grabación'
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.smAndDown
     }
   },
   mounted() {


### PR DESCRIPTION
## Context

Auto complete is broken in iPhone inside the v-modal.

This is a issue of veutify, we mare making some work around to improve the experience

## Test

Try in mobile view:

Go to materials, filter by tag, see that the tag input looks ok on searching 
Go to materials, add new material, check the tag input looks good on selecting 

## Platform

iPhone Emulator, Android

 
